### PR TITLE
EDR-4978: added areAllRequiredPermissionsGranted()

### DIFF
--- a/android/src/main/java/com/reactnativetelematicssdk/TelematicsSdkModule.java
+++ b/android/src/main/java/com/reactnativetelematicssdk/TelematicsSdkModule.java
@@ -104,6 +104,11 @@ public class TelematicsSdkModule extends ReactContextBaseJavaModule implements A
     }
   }
 
+  @ReactMethod
+  public void areAllRequiredPermissionsGranted(Promise promise) {
+    promise.resolve(api.areAllRequiredPermissionsGranted());
+  }
+
   // API Status
   @ReactMethod
   public void getStatus(Promise promise) {

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -128,6 +128,20 @@ export default function App() {
     }
   };
 
+  const checkPermissionsStatus = async () => {
+    try {
+      const isGranted = await TelematicsSdk.areAllRequiredPermissionsGranted();
+      Alert.alert(
+        'Permissions Status',
+        isGranted ? 'All permissions are granted' : 'Not all permissions are granted',
+        [{ text: 'OK' }]
+      );
+    } catch (error: any) {
+      Alert.alert('Error', error.message, [{ text: 'OK' }]);
+      console.log(error);
+    }
+  };
+
   return (
     <SafeAreaView style={styles.container}>
       {sdkTag === '' ? (
@@ -154,6 +168,9 @@ export default function App() {
       />
       <Text style={styles.tagText}>{sdkTag}</Text>
       <View>
+        <TouchableOpacity onPress={checkPermissionsStatus} style={styles.button}>
+          <Text>Check Permissions Status</Text>
+        </TouchableOpacity>
         <TouchableOpacity onPress={enableSDK} style={styles.button}>
           <Text>Enable SDK</Text>
         </TouchableOpacity>

--- a/ios/TelematicsSdk.m
+++ b/ios/TelematicsSdk.m
@@ -20,6 +20,10 @@ RCT_EXTERN_METHOD(requestPermissions:
                   (RCTPromiseResolveBlock)resolve
                   rejecter: (RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(areAllRequiredPermissionsGranted:
+                  (RCTPromiseResolveBlock)resolve
+                  rejecter: (RCTPromiseRejectBlock)reject)
+
 RCT_EXTERN_METHOD(getStatus:
                   (RCTPromiseResolveBlock)resolve
                   rejecter: (RCTPromiseRejectBlock)reject)

--- a/ios/TelematicsSdk.swift
+++ b/ios/TelematicsSdk.swift
@@ -41,6 +41,11 @@ class TelematicsSdk: RCTEventEmitter, RPLowPowerModeDelegate, RPLocationDelegate
         }
     }
     
+    @objc(areAllRequiredPermissionsGranted:rejecter:)
+    func areAllRequiredPermissionsGranted(_ resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+        resolve(RPEntry.instance.isAllRequiredPermissionsGranted())
+    }
+    
     // Enabling and disabling SDK
     @objc(enable:resolver:rejecter:)
     func enable(_ token: NSString, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,6 +13,7 @@ interface TelematicsSdkType {
   initialize: () => Promise<void>;
 
   requestPermissions: () => Promise<boolean>;
+  areAllRequiredPermissionsGranted: () => Promise<boolean>;
   enable: (token: string) => Promise<boolean>;
   getStatus: () => Promise<boolean>;
   getDeviceToken: () => Promise<string>;


### PR DESCRIPTION
This pull request adds a new feature to check whether all required permissions are granted in the Telematics SDK, and surfaces this functionality across Android, iOS, and the React Native interface. It also updates the example app to allow users to check the permissions status via a new UI button.

Platform and SDK interface updates:

* Android: Added a new method `areAllRequiredPermissionsGranted` to `TelematicsSdkModule` that resolves the current permissions status.
* iOS: Added an Objective-C bridge and Swift implementation for `areAllRequiredPermissionsGranted`, exposing the permission check to React Native. [[1]](diffhunk://#diff-161f88d5c4399456158757f000000006eb2bb94dbba267c5847c70e2afc81a91R23-R26) [[2]](diffhunk://#diff-62d7ce55fb97b7813cd220dc0e95be68ed68de35d5187a23305354fe1a4be370R44-R48)
* React Native JS: Extended the `TelematicsSdkType` interface and implementation to include the new `areAllRequiredPermissionsGranted` method.

Example app enhancements:

* Added a new function `checkPermissionsStatus` in `App.tsx` to call the new permissions API and display the result in an alert.
* Added a "Check Permissions Status" button to the example app UI, invoking the new check when pressed.